### PR TITLE
Allow disabling subdirectory depth check

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ I wrote this because I'm not good at key combos and prefer using a mouse for sea
 | Auto Search | Automatically search after 1 second instead of manually pressing enter | true | Boolean |
 | Case Sensitive | Case sensitive search | false | Boolean |
 | Codicon | The codicon that shows up on the side of the filename. Alternatives include `file-binary`, `book`, and more. | file | String |
-| Depth | The depth of subfolders to include in the search. | 0 | Number 0-5 |
+| Depth | The depth of subfolders to include in the search. -1 enables searching the whole tree. | 3 | Number -1 - 10 |
 | Folder | The folder to look for workspace files in. If Folder is empty, your home folder will be used. | None (all of your current workspaces will be used) | String |
 | Include File Types | Return only these specific file types. Example: php, ts, ps1 | | String |
 | Search minimum | The minimum number of workspaces required before the search box is displayed. 0 Will always display the search box. | 15 | Number 0-100 |

--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
         },
         "filenameSearchSidebar.depth": {
           "default": 3,
-          "description": "What depth of subfolders should also be looked in. Range: 0-5",
-          "maximum": 5,
-          "minimum": 0,
+          "description": "What depth of subfolders should also be looked in. Allowed values from -1 to 10. -1 enables searching the whole tree.",
+          "maximum": 10,
+          "minimum": -1,
           "scope": "application",
           "type": "number"
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,7 +1,7 @@
 {
   "config.title": "File Search Sidebar",
   "config.workspaceFolder.description": "The folder to look in for workspace files. This extension will return files from your workspace by default.",
-  "config.workspaceFolderDepth.description": "What depth of subfolders should also be looked in. Range: 0-5",
+  "config.workspaceFolderDepth.description": "What depth of subfolders should also be looked in. Allowed values from -1 to 10. -1 enables searching the whole tree.",
   "config.workspaceSearchMinimum.description": "The minimum number of workspace files required for the search box to be displayed. 0 will always show the search box. Range: 0-100",
   "config.workspaceShowPath.always": "Always show paths",
   "config.workspaceShowPath.asneeded": "Show paths when a workspace has the same label as another",

--- a/src/utils/fs/collectFilesFromFolder.ts
+++ b/src/utils/fs/collectFilesFromFolder.ts
@@ -11,7 +11,7 @@ export const collectFilesFromFolder = async (
   maxDepth: number,
   curDepth: number
 ): Promise<WsFiles | false> => {
-  if (curDepth <= maxDepth) {
+  if (maxDepth === -1 || curDepth <= maxDepth) {
     try {
       var foldersToIgnoreconfig: string =
         workspace.getConfiguration().get('filenameSearchSidebar.excludeFolders') || ''; // Folders that slow down collection or won't have workspace files in


### PR DESCRIPTION
Hi, I've found your extension when looking for a way to filter files by name - the native VS Code way sucks because [it doesn't look in folders in your workspace you haven't previously opened](https://github.com/microsoft/vscode/issues/66971). But your extension was also useless to me, because it's arbitrarily limited to 5 levels of subfolders, and my tree goes deeper than that.

So, this PR increases the limit to 10, and adds a way to disable the limit by setting `filenameSearchSidebar.depth` to `-1`. I haven't touched the default value, but I think it should search the whole tree by default, or maybe something north from 5 folders, as that would be enough for most projects.